### PR TITLE
fix: apply hira-kata transliterator after to-fullwidth

### DIFF
--- a/csharp/src/Yosina/TransliterationRecipe.cs
+++ b/csharp/src/Yosina/TransliterationRecipe.cs
@@ -585,7 +585,7 @@ public record class TransliterationRecipe
         if (this.HiraKata is HiraKataMode hiraKata)
         {
             var options = new HiraKataTransliterator.Options { Mode = hiraKata };
-            ctx = ctx.InsertMiddle(new TransliteratorConfig("hira-kata", options), false);
+            ctx = ctx.InsertTail(new TransliteratorConfig("hira-kata", options), false);
         }
 
         return ctx;

--- a/csharp/test/Yosina.Tests/TransliterationRecipeTests.cs
+++ b/csharp/test/Yosina.Tests/TransliterationRecipeTests.cs
@@ -476,5 +476,25 @@ public static class TransliterationRecipeTests
             // Emoji characters should not be processed
             Assert.Equal("🆘", transliterator("🆘"));
         }
+
+        [Fact]
+        public void ToFullwidth_MustComeBeforeHiraKata()
+        {
+            var recipe = new TransliterationRecipe
+            {
+                ToFullwidth = TransliterationRecipe.ToFullwidthOptions.Enabled,
+                HiraKata = Yosina.Transliterators.HiraKataTransliterator.Mode.KataToHira,
+            };
+
+            var configs = recipe.BuildTransliteratorConfigs();
+
+            Assert.Equal(2, configs.Count);
+            Assert.Equal("jisx0201-and-alike", configs[0].Name);
+            Assert.Equal("hira-kata", configs[1].Name);
+
+            // Test the actual transliteration works correctly
+            var transliterator = Entrypoint.MakeTransliterator(recipe);
+            Assert.Equal("かたかな", transliterator("ｶﾀｶﾅ"));
+        }
     }
 }

--- a/dart/lib/src/transliteration_recipe.dart
+++ b/dart/lib/src/transliteration_recipe.dart
@@ -374,7 +374,7 @@ class TransliterationRecipe {
   static void _applyHiraKata(
       _TransliteratorConfigListBuilder ctx, String? hiraKata) {
     if (hiraKata != null) {
-      ctx.insertMiddle(
+      ctx.insertTail(
         TransliteratorConfig('hiraKata', {'mode': hiraKata}),
         forceReplace: false,
       );

--- a/dart/test/transliteration_recipe_test.dart
+++ b/dart/test/transliteration_recipe_test.dart
@@ -551,5 +551,25 @@ void main() {
         expect(excludeEmojis.includeEmojis, isFalse);
       });
     });
+
+    test('toFullwidth must come before hiraKata', () {
+      final recipe = TransliterationRecipe(
+        toFullwidth: const ToFullwidthOptions.enabled(),
+        hiraKata: 'kata-to-hira',
+      );
+
+      final configs = recipe.buildTransliteratorConfigs();
+
+      expect(configs.length, equals(2));
+      expect(configs[0].name, equals('jisX0201AndAlike'));
+      expect(configs[1].name, equals('hiraKata'));
+
+      // Test the actual transliteration works correctly
+      final transliterator = Transliterator.withRecipe(recipe);
+      final input = Chars.fromString('ｶﾀｶﾅ');
+      final output = transliterator(input).toList();
+      final result = output.map((c) => c.c).join();
+      expect(result, equals('かたかな'));
+    });
   });
 }

--- a/go/recipe/make_transliterator.go
+++ b/go/recipe/make_transliterator.go
@@ -6,6 +6,7 @@ import (
 	yosina "github.com/yosina-lib/yosina/go"
 	"github.com/yosina-lib/yosina/go/transliterators/circled_or_squared"
 	"github.com/yosina-lib/yosina/go/transliterators/combined"
+	"github.com/yosina-lib/yosina/go/transliterators/hira_kata"
 	"github.com/yosina-lib/yosina/go/transliterators/hira_kata_composition"
 	"github.com/yosina-lib/yosina/go/transliterators/hyphens"
 	"github.com/yosina-lib/yosina/go/transliterators/ideographic_annotations"
@@ -136,6 +137,17 @@ func createTransliteratorFromConfig(config TransliteratorConfig) (yosina.Transli
 		}
 		return yosina.TransliteratorFunc(func(input yosina.CharIterator) (yosina.CharIterator, error) {
 			return prolonged_sound_marks.Transliterate(input, options), nil
+		}), nil
+
+	case "hira-kata":
+		var options hira_kata.Options
+		if config.Options != nil {
+			if opts, ok := config.Options.(*hira_kata.Options); ok {
+				options = *opts
+			}
+		}
+		return yosina.TransliteratorFunc(func(input yosina.CharIterator) (yosina.CharIterator, error) {
+			return hira_kata.Transliterate(input, options), nil
 		}), nil
 
 	case "hira-kata-composition":

--- a/go/recipe/recipe.go
+++ b/go/recipe/recipe.go
@@ -323,7 +323,7 @@ func (r *TransliterationRecipe) applyHiraKata(ctx *transliteratorConfigListBuild
 	default:
 		return
 	}
-	ctx.insertMiddle(TransliteratorConfig{
+	ctx.insertTail(TransliteratorConfig{
 		Name:    "hira-kata",
 		Options: &hira_kata.Options{Mode: mode},
 	}, false)

--- a/go/recipe/recipe_test.go
+++ b/go/recipe/recipe_test.go
@@ -473,6 +473,26 @@ func TestConfigurationOrdering(t *testing.T) {
 	assert.True(t, kanjiPos >= 0, "kanji-old-new should be present")
 }
 
+func TestToFullwidthMustComeBeforeHiraKata(t *testing.T) {
+	recipe := NewTransliterationRecipe()
+	recipe.ToFullwidth = Yes
+	recipe.HiraKata = KataToHira
+
+	configs, err := recipe.BuildTransliteratorConfigs()
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, len(configs))
+	assert.Equal(t, "jisx0201-and-alike", configs[0].Name)
+	assert.Equal(t, "hira-kata", configs[1].Name)
+
+	// Test the actual transliteration works correctly
+	transliterator, err := MakeTransliterator(recipe)
+	require.NoError(t, err)
+
+	result := transliterator("ｶﾀｶﾅ")
+	assert.Equal(t, "かたかな", result)
+}
+
 // Helper functions
 func containsConfig(configs []TransliteratorConfig, name string) bool {
 	for _, config := range configs {

--- a/java/src/main/java/io/yosina/TransliterationRecipe.java
+++ b/java/src/main/java/io/yosina/TransliterationRecipe.java
@@ -841,7 +841,7 @@ public class TransliterationRecipe {
                             : io.yosina.transliterators.HiraKataTransliterator.Options.Mode
                                     .KATA_TO_HIRA;
             ctx =
-                    ctx.insertMiddle(
+                    ctx.insertTail(
                             new Yosina.TransliteratorConfig(
                                     "hira-kata",
                                     Optional.of(

--- a/java/src/test/java/io/yosina/TransliterationRecipeTest.java
+++ b/java/src/test/java/io/yosina/TransliterationRecipeTest.java
@@ -536,6 +536,22 @@ public class TransliterationRecipeTest {
             // Emoji characters should not be processed
             assertEquals("🆘", transliterator.apply("🆘"));
         }
+
+        @Test
+        public void testToFullwidthMustComeBeforeHiraKata() {
+            recipe.withToFullwidth(TransliterationRecipe.ToFullwidthOptions.ENABLED)
+                    .withHiraKata("kata-to-hira");
+
+            List<Yosina.TransliteratorConfig> configs = recipe.buildTransliteratorConfigs();
+
+            assertEquals(2, configs.size());
+            assertEquals("jisx0201-and-alike", configs.get(0).getName());
+            assertEquals("hira-kata", configs.get(1).getName());
+
+            // Test the actual transliteration works correctly
+            Function<String, String> transliterator = Yosina.makeTransliteratorFromRecipe(recipe);
+            assertEquals("かたかな", transliterator.apply("ｶﾀｶﾅ"));
+        }
     }
 
     // Helper methods

--- a/javascript/src/__tests__/recipes.test.ts
+++ b/javascript/src/__tests__/recipes.test.ts
@@ -427,4 +427,18 @@ describe("Functional Integration", () => {
     // Emoji characters should not be processed
     expect(fromChars(transliterator(buildCharArray("🆘")))).toBe("🆘");
   });
+
+  it("to_fullwidth must come before hira-kata", async () => {
+    const configs = buildTransliteratorConfigsFromRecipe({
+      toFullwidth: true,
+      hiraKata: "kata-to-hira",
+    });
+
+    expect(configs).toHaveLength(2);
+    expect(configs[0][0]).toBe("jisx0201-and-alike");
+    expect(configs[1][0]).toBe("hira-kata");
+
+    const transliterator = await makeChainedTransliterator(configs);
+    expect(fromChars(transliterator(buildCharArray("ｶﾀｶﾅ")))).toBe("かたかな");
+  });
 });

--- a/javascript/src/recipes.ts
+++ b/javascript/src/recipes.ts
@@ -282,7 +282,7 @@ const transliteratorAppliers: {
 } = {
   kanjiOldNew: (ctx, recipe) =>
     recipe.kanjiOldNew ? insertMiddle(removeIVSSVS(ctx, false, recipe.charset), ["kanji-old-new", {}]) : ctx,
-  hiraKata: (ctx, recipe) => (recipe.hiraKata ? insertMiddle(ctx, ["hira-kata", { mode: recipe.hiraKata }]) : ctx),
+  hiraKata: (ctx, recipe) => (recipe.hiraKata ? insertTail(ctx, ["hira-kata", { mode: recipe.hiraKata }]) : ctx),
   replaceJapaneseIterationMarks: (ctx, recipe) => {
     if (!recipe.replaceJapaneseIterationMarks) return ctx;
     // Insert HiraKataComposition at head to ensure composed forms

--- a/php/src/TransliterationRecipe.php
+++ b/php/src/TransliterationRecipe.php
@@ -218,7 +218,7 @@ readonly class TransliterationRecipe
     private function applyHiraKata(TransliteratorConfigListBuilder $ctx): TransliteratorConfigListBuilder
     {
         if ($this->hiraKata !== null) {
-            $ctx = $ctx->insertMiddle(['hira-kata', ['mode' => $this->hiraKata]], false);
+            $ctx = $ctx->insertTail(['hira-kata', ['mode' => $this->hiraKata]], false);
         }
         return $ctx;
     }

--- a/php/tests/TransliterationRecipeTest.php
+++ b/php/tests/TransliterationRecipeTest.php
@@ -426,4 +426,22 @@ class TransliterationRecipeTest extends TestCase
         // Emoji characters should not be processed
         $this->assertEquals('🆘', $transliterator('🆘'));
     }
+
+    public function testToFullwidthMustComeBeforeHiraKata(): void
+    {
+        $recipe = new TransliterationRecipe(
+            toFullwidth: true,
+            hiraKata: 'kata-to-hira'
+        );
+        
+        $configs = $recipe->buildTransliteratorConfigs();
+        
+        $this->assertCount(2, $configs);
+        $this->assertEquals('jisx0201-and-alike', $configs[0][0]);
+        $this->assertEquals('hira-kata', $configs[1][0]);
+        
+        // Test the actual transliteration works correctly
+        $transliterator = Yosina::makeTransliterator($recipe);
+        $this->assertEquals('かたかな', $transliterator('ｶﾀｶﾅ'));
+    }
 }

--- a/python/src/yosina/recipes.py
+++ b/python/src/yosina/recipes.py
@@ -290,7 +290,7 @@ class _TransliteratorConfigListBuilder:
     ) -> _TransliteratorConfigListBuilder:
         ctx = self
         if recipe.hira_kata:
-            ctx = ctx.insert_middle(("hira-kata", {"mode": recipe.hira_kata}))
+            ctx = ctx.insert_tail(("hira-kata", {"mode": recipe.hira_kata}))
         return ctx
 
     def apply_replace_japanese_iteration_marks(

--- a/python/tests/test_recipe.py
+++ b/python/tests/test_recipe.py
@@ -399,3 +399,19 @@ class TestFunctionalIntegration:
 
         # Emoji characters should not be processed
         assert transliterator("🆘") == "🆘"  # Should remain unchanged
+
+    def test_to_fullwidth_must_come_before_hira_kata(self):
+        """Test that to_fullwidth comes before hira_kata in config order."""
+        recipe = TransliterationRecipe(
+            to_fullwidth=True,
+            hira_kata="kata-to-hira",
+        )
+        configs = build_transliterator_configs_from_recipe(recipe)
+
+        assert len(configs) == 2
+        assert configs[0][0] == "jisx0201-and-alike"
+        assert configs[1][0] == "hira-kata"
+
+        # Test the actual transliteration works correctly
+        transliterator = make_transliterator(recipe)
+        assert transliterator("ｶﾀｶﾅ") == "かたかな"

--- a/ruby/lib/yosina/recipes.rb
+++ b/ruby/lib/yosina/recipes.rb
@@ -241,7 +241,7 @@ module Yosina
 
     def apply_hira_kata(ctx)
       if @hira_kata
-        ctx.insert_middle([:hira_kata, { mode: @hira_kata }])
+        ctx.insert_tail([:hira_kata, { mode: @hira_kata }])
       else
         ctx
       end

--- a/ruby/test/test_recipes.rb
+++ b/ruby/test/test_recipes.rb
@@ -380,6 +380,23 @@ class TestFunctionalIntegration < Minitest::Test
     # Emoji characters should not be processed
     assert_equal "\u{1f198}", transliterator.call("\u{1f198}")  # Should remain unchanged
   end
+
+  def test_to_fullwidth_must_come_before_hira_kata
+    recipe = Yosina::TransliterationRecipe.new(
+      to_fullwidth: true,
+      hira_kata: 'kata-to-hira'
+    )
+
+    configs = recipe.build_transliterator_configs
+
+    assert_equal 2, configs.length
+    assert_equal :jisx0201_and_alike, configs[0][0]
+    assert_equal :hira_kata, configs[1][0]
+
+    # Test the actual transliteration works correctly
+    transliterator = Yosina.make_transliterator(recipe)
+    assert_equal 'かたかな', transliterator.call('ｶﾀｶﾅ')
+  end
 end
 
 # Shared helper module

--- a/rust/src/recipes.rs
+++ b/rust/src/recipes.rs
@@ -448,7 +448,7 @@ impl TransliterationRecipe {
     ) {
         match &self.hira_kata {
             HiraKataOptions::HiraToKata => {
-                builder = builder.insert_middle(
+                builder = builder.insert_tail(
                     TransliteratorConfig::HiraKata(
                         crate::transliterators::HiraKataTransliteratorOptions {
                             mode: crate::transliterators::HiraKataMode::HiraToKata,
@@ -458,7 +458,7 @@ impl TransliterationRecipe {
                 );
             }
             HiraKataOptions::KataToHira => {
-                builder = builder.insert_middle(
+                builder = builder.insert_tail(
                     TransliteratorConfig::HiraKata(
                         crate::transliterators::HiraKataTransliteratorOptions {
                             mode: crate::transliterators::HiraKataMode::KataToHira,

--- a/rust/tests/test_recipe.rs
+++ b/rust/tests/test_recipe.rs
@@ -741,6 +741,41 @@ fn test_roman_numerals_functional() {
 
     for (input, expected) in test_cases {
         let result = transliterator(input).unwrap();
-        assert_eq!(result, expected, "Failed for input '{}'", input);
+        assert_eq!(result, expected, "Failed for input '{input}'");
     }
+}
+
+#[test]
+fn test_to_fullwidth_must_come_before_hira_kata() {
+    use yosina::recipes::HiraKataOptions;
+
+    let recipe = TransliterationRecipe {
+        to_fullwidth: ToFullWidthOptions::Yes {
+            u005c_as_yen_sign: true,
+        },
+        hira_kata: HiraKataOptions::KataToHira,
+        ..Default::default()
+    };
+
+    let configs = recipe.build().unwrap();
+
+    assert_eq!(configs.len(), 2);
+
+    // Check the order of configs
+    match &configs[0] {
+        yosina::transliterators::TransliteratorConfig::Jisx0201AndAlike {
+            fullwidth_to_halfwidth: _,
+            options: _,
+        } => {}
+        _ => panic!("Expected jisx0201-and-alike as first config"),
+    }
+
+    match &configs[1] {
+        yosina::transliterators::TransliteratorConfig::HiraKata(_) => {}
+        _ => panic!("Expected hira-kata as second config"),
+    }
+
+    // Test the actual transliteration works correctly
+    let transliterator = make_transliterator(&recipe).unwrap();
+    assert_eq!(transliterator("ｶﾀｶﾅ").unwrap(), "かたかな");
 }

--- a/rust/tests/test_roman_numerals.rs
+++ b/rust/tests/test_roman_numerals.rs
@@ -79,7 +79,7 @@ const EDGE_TEST_CASES: &[(&str, &str, &str)] = &[
 fn test_uppercase_roman_numerals() {
     for (input, expected, description) in UPPERCASE_TEST_CASES {
         let result = test_transliterate(input);
-        assert_eq!(result, *expected, "Failed for test case: {}", description);
+        assert_eq!(result, *expected, "Failed for test case: {description}");
     }
 }
 
@@ -87,7 +87,7 @@ fn test_uppercase_roman_numerals() {
 fn test_lowercase_roman_numerals() {
     for (input, expected, description) in LOWERCASE_TEST_CASES {
         let result = test_transliterate(input);
-        assert_eq!(result, *expected, "Failed for test case: {}", description);
+        assert_eq!(result, *expected, "Failed for test case: {description}");
     }
 }
 
@@ -95,7 +95,7 @@ fn test_lowercase_roman_numerals() {
 fn test_mixed_text() {
     for (input, expected, description) in MIXED_TEXT_TEST_CASES {
         let result = test_transliterate(input);
-        assert_eq!(result, *expected, "Failed for test case: {}", description);
+        assert_eq!(result, *expected, "Failed for test case: {description}");
     }
 }
 
@@ -103,6 +103,6 @@ fn test_mixed_text() {
 fn test_edge_cases() {
     for (input, expected, description) in EDGE_TEST_CASES {
         let result = test_transliterate(input);
-        assert_eq!(result, *expected, "Failed for test case: {}", description);
+        assert_eq!(result, *expected, "Failed for test case: {description}");
     }
 }

--- a/swift/Sources/Yosina/TransliterationRecipe.swift
+++ b/swift/Sources/Yosina/TransliterationRecipe.swift
@@ -339,7 +339,7 @@ public struct TransliterationRecipe: TransliteratorFactory {
     private func applyHiraKata(to builder: TransliteratorConfigListBuilder) {
         if let hiraKata = hiraKata {
             let options = HiraKataTransliterator.Options(mode: hiraKata)
-            builder.insertMiddle(.hiraKata(options: options), forceReplace: false)
+            builder.insertTail(.hiraKata(options: options), forceReplace: false)
         }
     }
 

--- a/swift/Tests/YosinaTests/TransliterationRecipeTests.swift
+++ b/swift/Tests/YosinaTests/TransliterationRecipeTests.swift
@@ -473,4 +473,32 @@ final class TransliterationRecipeTests: XCTestCase {
         let ivsSvsTransliterators = config.compactMap { if case .ivsSvsBase = $0 { return $0 } else { return nil } }
         XCTAssertEqual(ivsSvsTransliterators.count, 2)
     }
+
+    func testToFullwidthMustComeBeforeHiraKata() throws {
+        let recipe = TransliterationRecipe(
+            hiraKata: .kataToHira,
+            toFullwidth: .enabled,
+        )
+        let config = try recipe.buildTransliteratorConfig()
+
+        XCTAssertEqual(config.count, 2)
+
+        // Check first config is jisx0201-and-alike
+        if case .jisx0201AndAlike = config[0] {
+            // correct
+        } else {
+            XCTFail("Expected jisx0201-and-alike as first config")
+        }
+
+        // Check second config is hira-kata
+        if case .hiraKata = config[1] {
+            // correct
+        } else {
+            XCTFail("Expected hira-kata as second config")
+        }
+
+        // Test the actual transliteration works correctly
+        let transliterator = try recipe.makeTransliterator()
+        XCTAssertEqual(transliterator.transliterate("ｶﾀｶﾅ"), "かたかな")
+    }
 }


### PR DESCRIPTION
## Summary

It's quite natural to consider that half-width katakanas are also converted to hiraganas when `to-fullwidth` and `hira-kata` transliterators are applied, however, the current recipe implementation doesn't work in such a way. This PR modifies the behavior more intuitive.