### PR TITLE
fix: lowercase "X" in jisx0201

### DIFF
--- a/csharp/src/Yosina.Codegen/Generators/HyphensTransliteratorGenerator.cs
+++ b/csharp/src/Yosina.Codegen/Generators/HyphensTransliteratorGenerator.cs
@@ -36,44 +36,44 @@ public static class HyphensTransliteratorGenerator
         mappingSections.Add(FormatMappingsSection(Mapping.ASCII, asciiEntries));
 
         // JISX0201 mappings
-        var jisX0201Entries = records
+        var jisx0201Entries = records
             .Where(r => r.Jisx0201 != null && r.Jisx0201.Length > 0)
             .Select(r =>
             {
                 var targetArray = FormatCodePointArrayFromInts(r.Jisx0201!);
                 return FormatArrayMappingEntry(r.Code, targetArray);
             });
-        mappingSections.Add(FormatMappingsSection(Mapping.JISX0201, jisX0201Entries));
+        mappingSections.Add(FormatMappingsSection(Mapping.JISX0201, jisx0201Entries));
 
         // JISX0208_90 mappings
-        var jisX0208Entries = records
+        var jisx0208Entries = records
             .Where(r => r.Jisx02081978 != null && r.Jisx02081978.Length > 0)
             .Select(r =>
             {
                 var targetArray = FormatCodePointArrayFromInts(r.Jisx02081978!);
                 return FormatArrayMappingEntry(r.Code, targetArray);
             });
-        mappingSections.Add(FormatMappingsSection(Mapping.JISX0208_90, jisX0208Entries));
+        mappingSections.Add(FormatMappingsSection(Mapping.JISX0208_90, jisx0208Entries));
 
         // JISX0208_90_WINDOWS mappings
-        var jisX0208WindowsEntries = records
+        var jisx0208WindowsEntries = records
             .Where(r => r.Jisx02081978Windows != null && r.Jisx02081978Windows.Length > 0)
             .Select(r =>
             {
                 var targetArray = FormatCodePointArrayFromInts(r.Jisx02081978Windows!);
                 return FormatArrayMappingEntry(r.Code, targetArray);
             });
-        mappingSections.Add(FormatMappingsSection(Mapping.JISX0208_90_WINDOWS, jisX0208WindowsEntries));
+        mappingSections.Add(FormatMappingsSection(Mapping.JISX0208_90_WINDOWS, jisx0208WindowsEntries));
 
         // JISX0208_VERBATIM mappings
-        var jisX0208VerbatimEntries = records
+        var jisx0208VerbatimEntries = records
             .Where(r => r.Jisx0208Verbatim != null)
             .Select(r =>
             {
                 var targetArray = FormatCodePointArrayFromInts(new[] { r.Jisx0208Verbatim!.Value });
                 return FormatArrayMappingEntry(r.Code, targetArray);
             });
-        mappingSections.Add(FormatMappingsSection(Mapping.JISX0208_VERBATIM, jisX0208VerbatimEntries));
+        mappingSections.Add(FormatMappingsSection(Mapping.JISX0208_VERBATIM, jisx0208VerbatimEntries));
 
         var mappingsData = string.Join("\n", mappingSections);
 

--- a/dart/README.md
+++ b/dart/README.md
@@ -123,7 +123,7 @@ Handles Ideographic and Standardized Variation Selectors.
 Expands iteration marks by repeating the preceding character.
 - Example: `時々` → `時時`, `いすゞ` → `いすず`
 
-### 9. **JIS X 0201 and Alike** (`jisX0201AndAlike`)
+### 9. **JIS X 0201 and Alike** (`jisx0201AndAlike`)
 Handles half-width/full-width character conversion.
 - Options: `fullwidthToHalfwidth`, `convertGL` (alphanumerics/symbols), `convertGR` (katakana), `u005cAsYenSign`
 - Example: `ABC123` → `ＡＢＣ１２３`, `ｶﾀｶﾅ` → `カタカナ`

--- a/dart/example/advanced_usage.dart
+++ b/dart/example/advanced_usage.dart
@@ -131,7 +131,7 @@ void main() {
         'Width',
         [
           {
-            'name': 'jisX0201AndAlike',
+            'name': 'jisx0201AndAlike',
             'options': {
               'u005cAsYenSign': false,
             },

--- a/dart/example/config_based_usage.dart
+++ b/dart/example/config_based_usage.dart
@@ -15,7 +15,7 @@ void main() {
         'replaceProlongedMarksFollowingAlnums': true,
       },
     },
-    {'name': 'jisX0201AndAlike'},
+    {'name': 'jisx0201AndAlike'},
   ]);
 
   print('--- Configuration-based Transliteration ---');
@@ -71,7 +71,7 @@ void main() {
   // JIS X 0201 conversion only
   final jisx0201Only = Transliterator.withMap([
     {
-      'name': 'jisX0201AndAlike',
+      'name': 'jisx0201AndAlike',
       'options': {
         'fullwidthToHalfwidth': false,
       },

--- a/dart/lib/src/transliteration_recipe.dart
+++ b/dart/lib/src/transliteration_recipe.dart
@@ -491,7 +491,7 @@ class TransliterationRecipe {
       _TransliteratorConfigListBuilder ctx, ToFullwidthOptions options) {
     if (options.isEnabled) {
       ctx.insertTail(
-        TransliteratorConfig('jisX0201AndAlike', {
+        TransliteratorConfig('jisx0201AndAlike', {
           'fullwidthToHalfwidth': false,
           'u005cAsYenSign': options.isU005cAsYenSign,
         }),
@@ -504,7 +504,7 @@ class TransliterationRecipe {
       _TransliteratorConfigListBuilder ctx, ToHalfwidthOptions options) {
     if (options.isEnabled) {
       ctx.insertTail(
-        TransliteratorConfig('jisX0201AndAlike', {
+        TransliteratorConfig('jisx0201AndAlike', {
           'fullwidthToHalfwidth': true,
           'convertGL': true,
           'convertGR': options.isHankakuKana,

--- a/dart/lib/src/transliteration_recipe.dart-e
+++ b/dart/lib/src/transliteration_recipe.dart-e
@@ -476,7 +476,7 @@ class TransliterationRecipe {
       _TransliteratorConfigListBuilder ctx, ToFullwidthOptions options) {
     if (options.isEnabled) {
       ctx.insertTail(
-        TransliteratorConfig('jisX0201AndAlike', {
+        TransliteratorConfig('jisx0201AndAlike', {
           'fullwidthToHalfwidth': false,
           'u005cAsYenSign': options.isU005cAsYenSign,
         }),
@@ -489,7 +489,7 @@ class TransliterationRecipe {
       _TransliteratorConfigListBuilder ctx, ToHalfwidthOptions options) {
     if (options.isEnabled) {
       ctx.insertTail(
-        TransliteratorConfig('jisX0201AndAlike', {
+        TransliteratorConfig('jisx0201AndAlike', {
           'fullwidthToHalfwidth': true,
           'convertGL': true,
           'convertGR': options.isHankakuKana,

--- a/dart/lib/src/transliterator_registry.dart
+++ b/dart/lib/src/transliterator_registry.dart
@@ -112,7 +112,7 @@ class TransliteratorRegistry {
                     options['dropSelectorsAltogether'] as bool? ?? false,
               ))
       ..register(
-          'jisX0201AndAlike',
+          'jisx0201AndAlike',
           (options) => Jisx0201AndAlikeTransliterator(
                 fullwidthToHalfwidth:
                     options['fullwidthToHalfwidth'] as bool? ?? true,

--- a/dart/test/transliteration_recipe_test.dart
+++ b/dart/test/transliteration_recipe_test.dart
@@ -193,7 +193,7 @@ void main() {
         final configs = recipe.buildTransliteratorConfigs();
 
         expect(configs.length, equals(1));
-        expect(configs[0].name, equals('jisX0201AndAlike'));
+        expect(configs[0].name, equals('jisx0201AndAlike'));
         expect(configs[0].options['fullwidthToHalfwidth'], isFalse);
         expect(configs[0].options['u005cAsYenSign'], isFalse);
       });
@@ -205,7 +205,7 @@ void main() {
         final configs = recipe.buildTransliteratorConfigs();
 
         expect(configs.length, equals(1));
-        expect(configs[0].name, equals('jisX0201AndAlike'));
+        expect(configs[0].name, equals('jisx0201AndAlike'));
         expect(configs[0].options['fullwidthToHalfwidth'], isFalse);
         expect(configs[0].options['u005cAsYenSign'], isTrue);
       });
@@ -217,7 +217,7 @@ void main() {
         final configs = recipe.buildTransliteratorConfigs();
 
         expect(configs.length, equals(1));
-        expect(configs[0].name, equals('jisX0201AndAlike'));
+        expect(configs[0].name, equals('jisx0201AndAlike'));
         expect(configs[0].options['fullwidthToHalfwidth'], isTrue);
         expect(configs[0].options['convertGL'], isTrue);
         expect(configs[0].options['convertGR'], isFalse);
@@ -230,7 +230,7 @@ void main() {
         final configs = recipe.buildTransliteratorConfigs();
 
         expect(configs.length, equals(1));
-        expect(configs[0].name, equals('jisX0201AndAlike'));
+        expect(configs[0].name, equals('jisx0201AndAlike'));
         expect(configs[0].options['fullwidthToHalfwidth'], isTrue);
         expect(configs[0].options['convertGL'], isTrue);
         expect(configs[0].options['convertGR'], isTrue);
@@ -352,14 +352,14 @@ void main() {
           'spaces',
           'hyphens',
           'mathematicalAlphanumerics',
-          'jisX0201AndAlike',
+          'jisx0201AndAlike',
         };
 
         final actualNames = names.toSet();
         expect(actualNames, equals(expectedNames));
 
         // Verify tail section exists (but don't assume order due to insert method)
-        expect(names, contains('jisX0201AndAlike'));
+        expect(names, contains('jisx0201AndAlike'));
         expect(names.where((name) => name == 'ivsSvsBase').length,
             equals(2)); // appears twice
       });
@@ -398,7 +398,7 @@ void main() {
           'spaces',
           'hyphens',
           'mathematicalAlphanumerics',
-          'jisX0201AndAlike',
+          'jisx0201AndAlike',
         };
 
         final actualNames = configs.map((c) => c.name).toSet();
@@ -413,7 +413,7 @@ void main() {
         expect(circledConfig.options['includeEmojis'], isFalse);
 
         final jisx0201Config =
-            configs.firstWhere((c) => c.name == 'jisX0201AndAlike');
+            configs.firstWhere((c) => c.name == 'jisx0201AndAlike');
         expect(jisx0201Config.options['convertGR'], isTrue);
 
         // Count ivs-svs-base occurrences
@@ -561,7 +561,7 @@ void main() {
       final configs = recipe.buildTransliteratorConfigs();
 
       expect(configs.length, equals(2));
-      expect(configs[0].name, equals('jisX0201AndAlike'));
+      expect(configs[0].name, equals('jisx0201AndAlike'));
       expect(configs[1].name, equals('hiraKata'));
 
       // Test the actual transliteration works correctly


### PR DESCRIPTION
## Summary

**This is an API breaking change.**

* The camelcased version of "JIS X 0201" is unstable, as it's rendered as "jisx0201" in the Rust version, while done as "jisX0201" in the Dart and C# versions.
* As "JIS" is an acronym and originally cased as all-capital, it should be safer to render "jisx" in the camelcased version.