### PR TITLE
fix: csharp codegen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,7 @@ codegen-php: $(PHP_GENERATED)
 
 $(CSHARP_GENERATED) &:: $(DATA_FILES)
 	@echo -e "$(BLUE)Generating C# code...$(NC)"
-	@cd csharp && dotnet run --project src/Yosina.Codegen/Yosina.Codegen.csproj && $(MAKE) format
+	@cd csharp && $(MAKE) codegen
 	@echo -e "$(GREEN)✓ C# code generation complete$(NC)"
 
 .PHONY: codegen-csharp

--- a/csharp/Makefile
+++ b/csharp/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build test format lint check clean restore
+.PHONY: all build test format lint check clean restore codegen
 
 # Default target
 all: format build test
@@ -34,6 +34,12 @@ lint: restore
 check: restore
 	@echo "Checking code format..."
 	@dotnet format --verify-no-changes --verbosity diagnostic
+
+# Run code generation
+codegen:
+	@echo "Running code generation..."
+	@dotnet run --project src/Yosina.Codegen/Yosina.Codegen.csproj
+	@$(MAKE) format
 
 # Clean build artifacts
 clean:

--- a/csharp/src/Yosina.Codegen/Generators/CircledOrSquaredTransliteratorGenerator.cs
+++ b/csharp/src/Yosina.Codegen/Generators/CircledOrSquaredTransliteratorGenerator.cs
@@ -35,7 +35,9 @@ public static class CircledOrSquaredTransliteratorGenerator
 
     private static string GenerateTemplate(string className, string registrationName, string description, string mappingsDict)
     {
-        return $@"namespace Yosina.Transliterators;
+        return $@"// Copyright (c) Yosina. All rights reserved.
+
+namespace Yosina.Transliterators;
 
 /// <summary>
 /// {description}
@@ -163,7 +165,7 @@ public class {className} : ITransliterator
 
                 // Get template
                 string template = data.Type == CharType.Circle ? this.options.TemplateForCircled : this.options.TemplateForSquared;
-                var replacement = template.Replace(""?"", data.Rendering);
+                var replacement = template.Replace(""?"", data.Rendering, StringComparison.Ordinal);
 
                 if (string.IsNullOrEmpty(replacement))
                 {{

--- a/csharp/src/Yosina.Codegen/Generators/CombinedTransliteratorGenerator.cs
+++ b/csharp/src/Yosina.Codegen/Generators/CombinedTransliteratorGenerator.cs
@@ -35,7 +35,9 @@ public static class CombinedTransliteratorGenerator
 
     private static string GenerateTemplate(string className, string registrationName, string description, string mappingsDict)
     {
-        return $@"namespace Yosina.Transliterators;
+        return $@"// Copyright (c) Yosina. All rights reserved.
+
+namespace Yosina.Transliterators;
 
 /// <summary>
 /// {description}

--- a/csharp/src/Yosina.Codegen/Generators/KanjiOldNewTransliteratorGenerator.cs
+++ b/csharp/src/Yosina.Codegen/Generators/KanjiOldNewTransliteratorGenerator.cs
@@ -38,7 +38,9 @@ public static class KanjiOldNewTransliteratorGenerator
 #pragma warning disable MA0051 // Method is too long
     private static string GenerateTemplate(string className, string registrationName, string description, string mappingsDict)
     {
-        return $@"using CodePointTuple = (int First, int Second);
+        return $@"// Copyright (c) Yosina. All rights reserved.
+
+using CodePointTuple = (int First, int Second);
 
 namespace Yosina.Transliterators;
 

--- a/csharp/src/Yosina.Codegen/Generators/SimpleTransliteratorGenerator.cs
+++ b/csharp/src/Yosina.Codegen/Generators/SimpleTransliteratorGenerator.cs
@@ -34,7 +34,9 @@ public static class SimpleTransliteratorGenerator
 #pragma warning disable MA0051 // Method is too long
     private static string GenerateTemplate(string className, string registrationName, string description, string mappingsDict)
     {
-        return $@"namespace Yosina.Transliterators;
+        return $@"// Copyright (c) Yosina. All rights reserved.
+
+namespace Yosina.Transliterators;
 
 /// <summary>
 /// {description}


### PR DESCRIPTION
## Summary

- Refactored C# codegen invocation in root `Makefile` to delegate to `csharp/Makefile`'s new `codegen` target
- Added `codegen` target to `csharp/Makefile` that runs the codegen project and formats output
- Added copyright headers (`// Copyright (c) Yosina. All rights reserved.`) to generated file templates in all generators
- Fixed `String.Replace` call in `CircledOrSquaredTransliteratorGenerator` to use `StringComparison.Ordinal` for correctness

## Test plan

- [x] Run `make codegen-csharp` and verify generated files include copyright headers
- [x] Verify `cd csharp && make codegen` works independently
- [x] Run `cd csharp && make check` to confirm formatting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)