### PR TITLE
fix: missing javadoc comments

### DIFF
--- a/java/codegen/src/main/java/io/yosina/codegen/AnnotationProcessor.java
+++ b/java/codegen/src/main/java/io/yosina/codegen/AnnotationProcessor.java
@@ -17,9 +17,16 @@ import javax.lang.model.element.TypeElement;
 import javax.tools.FileObject;
 import javax.tools.StandardLocation;
 
+/**
+ * Annotation processor that collects classes annotated with {@code RegisteredTransliterator} and
+ * writes a manifest resource listing their names and qualified class names.
+ */
 @SupportedAnnotationTypes("io.yosina.annotations.RegisteredTransliterator")
 @SupportedSourceVersion(javax.lang.model.SourceVersion.RELEASE_17)
 public class AnnotationProcessor extends AbstractProcessor {
+    /** Constructs a new {@code AnnotationProcessor}. */
+    public AnnotationProcessor() {}
+
     private static final String TRANSLITERATOR_ANNOTATION_TYPE =
             "io.yosina.annotations.RegisteredTransliterator";
     private static final String TRANSLITERATORS_PACKAGE = "io.yosina.transliterators";

--- a/java/codegen/src/main/java/io/yosina/codegen/Artifact.java
+++ b/java/codegen/src/main/java/io/yosina/codegen/Artifact.java
@@ -3,9 +3,13 @@ package io.yosina.codegen;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
 
+/** Represents a generated code or resource artifact produced during code generation. */
 public class Artifact {
+    /** The type of the artifact, either source code or a resource file. */
     public static enum Type {
+        /** A Java source file artifact. */
         SOURCE,
+        /** A resource file artifact. */
         RESOURCE
     }
 
@@ -13,18 +17,40 @@ public class Artifact {
     private final Path path;
     private final ByteBuffer content;
 
+    /**
+     * Returns the type of this artifact.
+     *
+     * @return the artifact type
+     */
     public Type getType() {
         return type;
     }
 
+    /**
+     * Returns the relative path of this artifact.
+     *
+     * @return the artifact path
+     */
     public Path getPath() {
         return path;
     }
 
+    /**
+     * Returns the content of this artifact.
+     *
+     * @return the artifact content as a {@link ByteBuffer}
+     */
     public ByteBuffer getContent() {
         return content;
     }
 
+    /**
+     * Constructs an {@code Artifact} with the given type, path, and content.
+     *
+     * @param type the artifact type
+     * @param path the relative path of the artifact
+     * @param content the content of the artifact
+     */
     public Artifact(Type type, Path path, ByteBuffer content) {
         this.type = type;
         this.path = path;

--- a/java/codegen/src/main/java/io/yosina/codegen/CircledOrSquaredRecord.java
+++ b/java/codegen/src/main/java/io/yosina/codegen/CircledOrSquaredRecord.java
@@ -13,32 +13,70 @@ public class CircledOrSquaredRecord {
     @JsonProperty("emoji")
     private boolean emoji;
 
+    /**
+     * Returns the rendering string of this record.
+     *
+     * @return the rendering
+     */
     public String getRendering() {
         return rendering;
     }
 
+    /**
+     * Sets the rendering string of this record.
+     *
+     * @param rendering the rendering to set
+     */
     public void setRendering(String rendering) {
         this.rendering = rendering;
     }
 
+    /**
+     * Returns the type of this record.
+     *
+     * @return the type
+     */
     public String getType() {
         return type;
     }
 
+    /**
+     * Sets the type of this record.
+     *
+     * @param type the type to set
+     */
     public void setType(String type) {
         this.type = type;
     }
 
+    /**
+     * Returns whether this record represents an emoji character.
+     *
+     * @return {@code true} if this is an emoji record
+     */
     public boolean isEmoji() {
         return emoji;
     }
 
+    /**
+     * Sets whether this record represents an emoji character.
+     *
+     * @param emoji {@code true} if this is an emoji record
+     */
     public void setEmoji(boolean emoji) {
         this.emoji = emoji;
     }
 
+    /** Constructs an empty {@code CircledOrSquaredRecord} for deserialization. */
     public CircledOrSquaredRecord() {}
 
+    /**
+     * Constructs a {@code CircledOrSquaredRecord} with the given values.
+     *
+     * @param rendering the rendering string
+     * @param type the character type
+     * @param emoji whether this is an emoji character
+     */
     public CircledOrSquaredRecord(String rendering, String type, boolean emoji) {
         this.rendering = rendering;
         this.type = type;

--- a/java/codegen/src/main/java/io/yosina/codegen/CodeGenerator.java
+++ b/java/codegen/src/main/java/io/yosina/codegen/CodeGenerator.java
@@ -18,12 +18,23 @@ public class CodeGenerator {
     private final Path sourceDir;
     private final Path resourceDir;
 
+    /**
+     * Constructs a {@code CodeGenerator} that writes sources to {@code sourceDir} and resources to
+     * {@code resourceDir}.
+     *
+     * @param sourceDir the directory for generated Java source files
+     * @param resourceDir the directory for generated resource files
+     */
     public CodeGenerator(Path sourceDir, Path resourceDir) {
         this.sourceDir = sourceDir;
         this.resourceDir = resourceDir;
     }
 
-    /** Writes the generated content to a file. */
+    /**
+     * Writes the generated content to files under the source or resource directory.
+     *
+     * @param artifacts the list of artifacts to write
+     */
     protected void writeToFile(List<Artifact> artifacts) {
         for (Artifact artifact : artifacts) {
             final Path outputPath;
@@ -58,20 +69,36 @@ public class CodeGenerator {
         }
     }
 
-    /** Generates a simple transliterator that maps single characters to single characters. */
+    /**
+     * Generates a simple transliterator that maps single characters to single characters.
+     *
+     * @param name the transliterator name (used for class and file naming)
+     * @param mappings the character mappings as arrays of code points
+     * @throws IOException if an I/O error occurs while writing the generated files
+     */
     public void generateSimpleTransliterator(String name, Map<int[], int[]> mappings)
             throws IOException {
         SimpleTransliteratorGenerator generator = new SimpleTransliteratorGenerator(name, mappings);
         writeToFile(generator.generate());
     }
 
-    /** Generates the hyphens transliterator. */
+    /**
+     * Generates the hyphens transliterator.
+     *
+     * @param records the list of hyphen replacement records
+     * @throws IOException if an I/O error occurs while writing the generated files
+     */
     public void generateHyphensTransliterator(List<HyphensRecord> records) throws IOException {
         HyphensTransliteratorGenerator generator = new HyphensTransliteratorGenerator(records);
         writeToFile(generator.generate());
     }
 
-    /** Generates the IVS/SVS base transliterator. */
+    /**
+     * Generates the IVS/SVS base transliterator.
+     *
+     * @param records the list of IVS/SVS base mapping records
+     * @throws IOException if an I/O error occurs while writing the generated files
+     */
     public void generateIvsSvsBaseTransliterator(List<IvsSvsBaseRecord> records)
             throws IOException {
         IvsSvsBaseTransliteratorGenerator generator =
@@ -79,7 +106,12 @@ public class CodeGenerator {
         writeToFile(generator.generate());
     }
 
-    /** Generates the kanji old-new transliterator. */
+    /**
+     * Generates the kanji old-new transliterator.
+     *
+     * @param records the list of kanji old-new form mapping records
+     * @throws IOException if an I/O error occurs while writing the generated files
+     */
     public void generateKanjiOldNewTransliterator(List<KanjiOldNewRecord> records)
             throws IOException {
         final Map<int[], int[]> records_ =
@@ -105,14 +137,24 @@ public class CodeGenerator {
         writeToFile(generator.generate());
     }
 
-    /** Generates the combined transliterator. */
+    /**
+     * Generates the combined transliterator.
+     *
+     * @param mappings the character mappings from Unicode notation to replacement strings
+     * @throws IOException if an I/O error occurs while writing the generated files
+     */
     public void generateCombinedTransliterator(Map<String, String> mappings) throws IOException {
         CombinedTransliteratorGenerator generator =
                 new CombinedTransliteratorGenerator(mappings, "CombinedTransliterator", "combined");
         writeToFile(generator.generate());
     }
 
-    /** Generates the circled-or-squared transliterator. */
+    /**
+     * Generates the circled-or-squared transliterator.
+     *
+     * @param mappings the circled/squared character mappings keyed by Unicode notation
+     * @throws IOException if an I/O error occurs while writing the generated files
+     */
     public void generateCircledOrSquaredTransliterator(Map<String, CircledOrSquaredRecord> mappings)
             throws IOException {
         CircledOrSquaredTransliteratorGenerator generator =
@@ -120,7 +162,12 @@ public class CodeGenerator {
         writeToFile(generator.generate());
     }
 
-    /** Generates the roman numerals transliterator. */
+    /**
+     * Generates the roman numerals transliterator.
+     *
+     * @param records the list of Roman numeral records
+     * @throws IOException if an I/O error occurs while writing the generated files
+     */
     public void generateRomanNumeralsTransliterator(List<RomanNumeralsRecord> records)
             throws IOException {
         // Convert records to a Map format similar to combined transliterator

--- a/java/codegen/src/main/java/io/yosina/codegen/HyphensRecord.java
+++ b/java/codegen/src/main/java/io/yosina/codegen/HyphensRecord.java
@@ -75,38 +75,90 @@ public class HyphensRecord {
 
     private int jisx0208_verbatim;
 
+    /**
+     * Returns the Unicode code point of this hyphen character.
+     *
+     * @return the Unicode code point
+     */
     public int getCode() {
         return code;
     }
 
+    /**
+     * Returns the Unicode name of this hyphen character.
+     *
+     * @return the character name
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Returns the ASCII equivalent code points for this hyphen.
+     *
+     * @return the ASCII code points, or {@code null} if not applicable
+     */
     public int[] getAscii() {
         return ascii;
     }
 
+    /**
+     * Returns the Shift-JIS byte sequence for this hyphen.
+     *
+     * @return the Shift-JIS bytes as integers
+     */
     public int[] getShiftJis() {
         return shiftJis;
     }
 
+    /**
+     * Returns the JIS X 0201 equivalent code points for this hyphen.
+     *
+     * @return the JIS X 0201 code points, or {@code null} if not applicable
+     */
     public int[] getJisx0201() {
         return jisx0201;
     }
 
+    /**
+     * Returns the JIS X 0208-1978 equivalent code points for this hyphen.
+     *
+     * @return the JIS X 0208-1978 code points, or {@code null} if not applicable
+     */
     public int[] getJisx0208_1978() {
         return jisx0208_1978;
     }
 
+    /**
+     * Returns the JIS X 0208-1978 (Windows variant) equivalent code points for this hyphen.
+     *
+     * @return the JIS X 0208-1978 Windows code points, or {@code null} if not applicable
+     */
     public int[] getJisx0208_1978_windows() {
         return jisx0208_1978_windows;
     }
 
+    /**
+     * Returns the verbatim JIS X 0208 code point for this hyphen.
+     *
+     * @return the verbatim JIS X 0208 code point
+     */
     public int getJisx0208_verbatim() {
         return jisx0208_verbatim;
     }
 
+    /**
+     * Constructs a {@code HyphensRecord} with all hyphen encoding fields.
+     *
+     * @param code the Unicode code point
+     * @param name the Unicode character name
+     * @param ascii the ASCII equivalent code points
+     * @param shiftJis the Shift-JIS byte sequence
+     * @param jisx0201 the JIS X 0201 equivalent code points
+     * @param jisx0208_1978 the JIS X 0208-1978 equivalent code points
+     * @param jisx0208_1978_windows the JIS X 0208-1978 Windows variant code points
+     * @param jisx0208_verbatim the verbatim JIS X 0208 code point
+     */
     public HyphensRecord(
             int code,
             String name,

--- a/java/codegen/src/main/java/io/yosina/codegen/IvsSvsBaseRecord.java
+++ b/java/codegen/src/main/java/io/yosina/codegen/IvsSvsBaseRecord.java
@@ -12,6 +12,7 @@ import java.util.List;
 /** Represents an IVS/SVS base mapping record. */
 @JsonDeserialize(using = IvsSvsBaseRecord.Deserializer.class)
 public class IvsSvsBaseRecord extends IvsSvsPair {
+    /** Jackson deserializer for {@link IvsSvsBaseRecord}. */
     public static class Deserializer extends StdDeserializer<IvsSvsPair> {
         private static final class _IvsSvsBaseRecord {
             @JsonProperty("ivs")
@@ -38,6 +39,7 @@ public class IvsSvsBaseRecord extends IvsSvsPair {
                     pair.base2004 != null ? UnicodeUtils.parseUnicodeCodepoint(pair.base2004) : -1);
         }
 
+        /** Constructs a {@code Deserializer} for {@link IvsSvsBaseRecord}. */
         public Deserializer() {
             super(IvsSvsBaseRecord.class);
         }
@@ -47,20 +49,40 @@ public class IvsSvsBaseRecord extends IvsSvsPair {
 
     private int base2004;
 
+    /**
+     * Returns the base code point under the UniJIS-90 (JIS X 0208-1990) standard, or {@code -1} if
+     * not applicable.
+     *
+     * @return the UniJIS-90 base code point
+     */
     public int getBase90() {
         return base90;
     }
 
+    /**
+     * Returns the base code point under the UniJIS-2004 standard, or {@code -1} if not applicable.
+     *
+     * @return the UniJIS-2004 base code point
+     */
     public int getBase2004() {
         return base2004;
     }
 
+    /**
+     * Constructs an {@code IvsSvsBaseRecord} with all fields.
+     *
+     * @param ivs the IVS code points
+     * @param svs the SVS code points
+     * @param base90 the UniJIS-90 base code point, or {@code -1}
+     * @param base2004 the UniJIS-2004 base code point, or {@code -1}
+     */
     public IvsSvsBaseRecord(int[] ivs, int[] svs, int base90, int base2004) {
         super(ivs, svs);
         this.base90 = base90;
         this.base2004 = base2004;
     }
 
+    /** Constructs an empty {@code IvsSvsBaseRecord} for deserialization. */
     public IvsSvsBaseRecord() {
         super();
         this.base90 = -1;

--- a/java/codegen/src/main/java/io/yosina/codegen/IvsSvsPair.java
+++ b/java/codegen/src/main/java/io/yosina/codegen/IvsSvsPair.java
@@ -12,6 +12,7 @@ import java.util.List;
 /** Represents a kanji old-new form mapping record. */
 @JsonDeserialize(using = IvsSvsPair.Deserializer.class)
 public class IvsSvsPair {
+    /** Jackson deserializer for {@link IvsSvsPair}. */
     public static class Deserializer extends StdDeserializer<IvsSvsPair> {
         private static final class _IvsSvsPair {
             @JsonProperty("ivs")
@@ -30,6 +31,7 @@ public class IvsSvsPair {
                     pair.svs != null ? UnicodeUtils.parseUnicodeCodepoint(pair.svs) : null);
         }
 
+        /** Constructs a {@code Deserializer} for {@link IvsSvsPair}. */
         public Deserializer() {
             super(IvsSvsPair.class);
         }
@@ -38,19 +40,36 @@ public class IvsSvsPair {
     private int[] ivs;
     private int[] svs;
 
+    /**
+     * Returns the IVS (Ideographic Variation Sequence) code points.
+     *
+     * @return the IVS code points, or {@code null} if absent
+     */
     public int[] getIvs() {
         return ivs;
     }
 
+    /**
+     * Returns the SVS (Standardized Variation Sequence) code points.
+     *
+     * @return the SVS code points, or {@code null} if absent
+     */
     public int[] getSvs() {
         return svs;
     }
 
+    /**
+     * Constructs an {@code IvsSvsPair} with the given IVS and SVS code points.
+     *
+     * @param ivs the IVS code points
+     * @param svs the SVS code points
+     */
     public IvsSvsPair(int[] ivs, int[] svs) {
         this.ivs = ivs;
         this.svs = svs;
     }
 
+    /** Constructs an empty {@code IvsSvsPair} for deserialization. */
     public IvsSvsPair() {
         this.ivs = null;
         this.svs = null;

--- a/java/codegen/src/main/java/io/yosina/codegen/KanjiOldNewRecord.java
+++ b/java/codegen/src/main/java/io/yosina/codegen/KanjiOldNewRecord.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 /** Represents a kanji old-new form mapping record. */
 @JsonDeserialize(using = KanjiOldNewRecord.Deserializer.class)
 public class KanjiOldNewRecord {
+    /** Jackson deserializer for {@link KanjiOldNewRecord}. */
     public static class Deserializer extends StdDeserializer<KanjiOldNewRecord> {
         @Override
         public KanjiOldNewRecord deserialize(JsonParser p, DeserializationContext ctxt)
@@ -27,6 +28,7 @@ public class KanjiOldNewRecord {
             return new KanjiOldNewRecord(pair[0], pair[1]);
         }
 
+        /** Constructs a {@code Deserializer} for {@link KanjiOldNewRecord}. */
         public Deserializer() {
             super(KanjiOldNewRecord.class);
         }
@@ -36,19 +38,36 @@ public class KanjiOldNewRecord {
 
     private IvsSvsPair new_;
 
+    /**
+     * Returns the traditional (old-form) kanji IVS/SVS pair.
+     *
+     * @return the traditional kanji pair
+     */
     public IvsSvsPair getTraditional() {
         return traditional;
     }
 
+    /**
+     * Returns the new-form kanji IVS/SVS pair.
+     *
+     * @return the new kanji pair
+     */
     public IvsSvsPair getNew() {
         return new_;
     }
 
+    /**
+     * Constructs a {@code KanjiOldNewRecord} with the given traditional and new form pairs.
+     *
+     * @param traditional the traditional (old-form) kanji pair
+     * @param new_ the new-form kanji pair
+     */
     public KanjiOldNewRecord(IvsSvsPair traditional, IvsSvsPair new_) {
         this.traditional = traditional;
         this.new_ = new_;
     }
 
+    /** Constructs an empty {@code KanjiOldNewRecord} for deserialization. */
     public KanjiOldNewRecord() {
         this.traditional = null;
         this.new_ = null;

--- a/java/codegen/src/main/java/io/yosina/codegen/Main.java
+++ b/java/codegen/src/main/java/io/yosina/codegen/Main.java
@@ -14,6 +14,15 @@ import java.util.stream.Collectors;
 public class Main {
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
+    /** Utility class; do not instantiate. */
+    private Main() {}
+
+    /**
+     * Entry point for the code generator.
+     *
+     * @param args command-line arguments (unused)
+     * @throws IOException if an I/O error occurs during code generation
+     */
     public static void main(String[] args) throws IOException {
         // Find project root by looking for build.gradle
         Path projectRoot = findProjectRoot();

--- a/java/codegen/src/main/java/io/yosina/codegen/RomanNumeralsRecord.java
+++ b/java/codegen/src/main/java/io/yosina/codegen/RomanNumeralsRecord.java
@@ -12,97 +12,212 @@ public class RomanNumeralsRecord {
     private ShiftJis shiftJis;
     private Decomposed decomposed;
 
+    /** Constructs an empty {@code RomanNumeralsRecord} for deserialization. */
+    public RomanNumeralsRecord() {}
+
+    /**
+     * Returns the numeric value of this Roman numeral.
+     *
+     * @return the numeric value
+     */
     public int getValue() {
         return value;
     }
 
+    /**
+     * Sets the numeric value of this Roman numeral.
+     *
+     * @param value the numeric value
+     */
     public void setValue(int value) {
         this.value = value;
     }
 
+    /**
+     * Returns the Unicode code strings for this Roman numeral.
+     *
+     * @return the codes, or {@code null} if absent
+     */
     public Codes getCodes() {
         return codes;
     }
 
+    /**
+     * Sets the Unicode code strings for this Roman numeral.
+     *
+     * @param codes the codes to set
+     */
     public void setCodes(Codes codes) {
         this.codes = codes;
     }
 
+    /**
+     * Returns the Shift-JIS encoding for this Roman numeral.
+     *
+     * @return the Shift-JIS data, or {@code null} if absent
+     */
     @JsonProperty("shift_jis")
     public ShiftJis getShiftJis() {
         return shiftJis;
     }
 
+    /**
+     * Sets the Shift-JIS encoding for this Roman numeral.
+     *
+     * @param shiftJis the Shift-JIS data to set
+     */
     public void setShiftJis(ShiftJis shiftJis) {
         this.shiftJis = shiftJis;
     }
 
+    /**
+     * Returns the decomposed form of this Roman numeral.
+     *
+     * @return the decomposed form, or {@code null} if absent
+     */
     public Decomposed getDecomposed() {
         return decomposed;
     }
 
+    /**
+     * Sets the decomposed form of this Roman numeral.
+     *
+     * @param decomposed the decomposed form to set
+     */
     public void setDecomposed(Decomposed decomposed) {
         this.decomposed = decomposed;
     }
 
+    /** Holds Unicode code strings for upper- and lower-case Roman numeral forms. */
     public static class Codes {
         private String upper;
         private String lower;
 
+        /** Constructs an empty {@code Codes} for deserialization. */
+        public Codes() {}
+
+        /**
+         * Returns the Unicode code string for the upper-case form.
+         *
+         * @return the upper-case code string
+         */
         public String getUpper() {
             return upper;
         }
 
+        /**
+         * Sets the Unicode code string for the upper-case form.
+         *
+         * @param upper the upper-case code string
+         */
         public void setUpper(String upper) {
             this.upper = upper;
         }
 
+        /**
+         * Returns the Unicode code string for the lower-case form.
+         *
+         * @return the lower-case code string
+         */
         public String getLower() {
             return lower;
         }
 
+        /**
+         * Sets the Unicode code string for the lower-case form.
+         *
+         * @param lower the lower-case code string
+         */
         public void setLower(String lower) {
             this.lower = lower;
         }
     }
 
+    /** Holds Shift-JIS byte sequences for upper- and lower-case Roman numeral forms. */
     public static class ShiftJis {
         private List<Integer> upper;
         private List<Integer> lower;
 
+        /** Constructs an empty {@code ShiftJis} for deserialization. */
+        public ShiftJis() {}
+
+        /**
+         * Returns the Shift-JIS bytes for the upper-case form.
+         *
+         * @return the upper-case Shift-JIS bytes
+         */
         public List<Integer> getUpper() {
             return upper;
         }
 
+        /**
+         * Sets the Shift-JIS bytes for the upper-case form.
+         *
+         * @param upper the upper-case Shift-JIS bytes
+         */
         public void setUpper(List<Integer> upper) {
             this.upper = upper;
         }
 
+        /**
+         * Returns the Shift-JIS bytes for the lower-case form.
+         *
+         * @return the lower-case Shift-JIS bytes
+         */
         public List<Integer> getLower() {
             return lower;
         }
 
+        /**
+         * Sets the Shift-JIS bytes for the lower-case form.
+         *
+         * @param lower the lower-case Shift-JIS bytes
+         */
         public void setLower(List<Integer> lower) {
             this.lower = lower;
         }
     }
 
+    /** Holds decomposed Unicode string sequences for upper- and lower-case Roman numeral forms. */
     public static class Decomposed {
         private List<String> upper;
         private List<String> lower;
 
+        /** Constructs an empty {@code Decomposed} for deserialization. */
+        public Decomposed() {}
+
+        /**
+         * Returns the decomposed strings for the upper-case form.
+         *
+         * @return the upper-case decomposed strings
+         */
         public List<String> getUpper() {
             return upper;
         }
 
+        /**
+         * Sets the decomposed strings for the upper-case form.
+         *
+         * @param upper the upper-case decomposed strings
+         */
         public void setUpper(List<String> upper) {
             this.upper = upper;
         }
 
+        /**
+         * Returns the decomposed strings for the lower-case form.
+         *
+         * @return the lower-case decomposed strings
+         */
         public List<String> getLower() {
             return lower;
         }
 
+        /**
+         * Sets the decomposed strings for the lower-case form.
+         *
+         * @param lower the lower-case decomposed strings
+         */
         public void setLower(List<String> lower) {
             this.lower = lower;
         }

--- a/java/codegen/src/main/java/io/yosina/codegen/generators/CircledOrSquaredTransliteratorGenerator.java
+++ b/java/codegen/src/main/java/io/yosina/codegen/generators/CircledOrSquaredTransliteratorGenerator.java
@@ -265,6 +265,11 @@ public class %1$s implements Transliterator {
     private final Map<String, CircledOrSquaredRecord> mappings;
     private final String className = "CircledOrSquaredTransliterator";
 
+    /**
+     * Constructs a {@code CircledOrSquaredTransliteratorGenerator} with the given mappings.
+     *
+     * @param mappings the circled/squared character mappings keyed by Unicode notation
+     */
     public CircledOrSquaredTransliteratorGenerator(Map<String, CircledOrSquaredRecord> mappings) {
         this.mappings = mappings;
     }

--- a/java/codegen/src/main/java/io/yosina/codegen/generators/CombinedTransliteratorGenerator.java
+++ b/java/codegen/src/main/java/io/yosina/codegen/generators/CombinedTransliteratorGenerator.java
@@ -131,6 +131,13 @@ public class %1$s implements Transliterator {
     private final String className;
     private final String name;
 
+    /**
+     * Constructs a {@code CombinedTransliteratorGenerator} with the given mappings and names.
+     *
+     * @param mappings the character mappings from Unicode notation to replacement strings
+     * @param className the simple class name for the generated transliterator
+     * @param name the transliterator identifier name used for the resource file
+     */
     public CombinedTransliteratorGenerator(
             Map<String, String> mappings, String className, String name) {
         this.mappings = mappings;

--- a/java/codegen/src/main/java/io/yosina/codegen/generators/HyphensTransliteratorGenerator.java
+++ b/java/codegen/src/main/java/io/yosina/codegen/generators/HyphensTransliteratorGenerator.java
@@ -293,6 +293,11 @@ public class HyphensTransliterator implements Transliterator {
 
     private final List<HyphensRecord> records;
 
+    /**
+     * Constructs a {@code HyphensTransliteratorGenerator} with the given records.
+     *
+     * @param records the list of hyphen replacement records
+     */
     public HyphensTransliteratorGenerator(List<HyphensRecord> records) {
         this.records = records;
     }
@@ -319,6 +324,11 @@ public class HyphensTransliterator implements Transliterator {
         return sb.toString();
     }
 
+    /**
+     * Renders the mapping entries as Java source code statements.
+     *
+     * @return a string containing the Java source code for mapping entries
+     */
     public String renderMappingEntries() {
         StringBuilder sb = new StringBuilder();
         for (HyphensRecord record : records) {

--- a/java/codegen/src/main/java/io/yosina/codegen/generators/IvsSvsBaseTransliteratorGenerator.java
+++ b/java/codegen/src/main/java/io/yosina/codegen/generators/IvsSvsBaseTransliteratorGenerator.java
@@ -404,6 +404,11 @@ public class IvsSvsBaseTransliterator implements Transliterator {
 
     private final List<IvsSvsBaseRecord> records;
 
+    /**
+     * Generates the binary mapping data for the IVS/SVS base transliterator.
+     *
+     * @return a {@link ByteBuffer} containing the serialized mapping data
+     */
     public ByteBuffer generateMappingData() {
         final ByteBuffer b =
                 ByteBuffer.allocate(4 + 24 * records.size()).order(ByteOrder.BIG_ENDIAN);
@@ -431,6 +436,11 @@ public class IvsSvsBaseTransliterator implements Transliterator {
                 new Artifact(Artifact.Type.RESOURCE, Path.of(dataFileName), generateMappingData()));
     }
 
+    /**
+     * Constructs an {@code IvsSvsBaseTransliteratorGenerator} with the given records.
+     *
+     * @param records the list of IVS/SVS base mapping records
+     */
     public IvsSvsBaseTransliteratorGenerator(List<IvsSvsBaseRecord> records) {
         this.records = records;
     }

--- a/java/codegen/src/main/java/io/yosina/codegen/generators/TransliteratorGenerator.java
+++ b/java/codegen/src/main/java/io/yosina/codegen/generators/TransliteratorGenerator.java
@@ -5,10 +5,19 @@ import java.util.List;
 
 /** Base class for transliterator generators. */
 public interface TransliteratorGenerator {
-    /** Generates the transliterator file. */
+    /**
+     * Generates the transliterator file.
+     *
+     * @return a list of generated {@link Artifact} instances
+     */
     public List<Artifact> generate();
 
-    /** Converts snake_case to PascalCase. */
+    /**
+     * Converts a snake_case string to PascalCase.
+     *
+     * @param snakeCase the snake_case string to convert
+     * @return the PascalCase equivalent
+     */
     public static String toCamelCase(String snakeCase) {
         StringBuilder result = new StringBuilder();
         boolean capitalizeNext = true;

--- a/java/examples/src/main/java/examples/AdvancedUsage.java
+++ b/java/examples/src/main/java/examples/AdvancedUsage.java
@@ -15,6 +15,14 @@ import io.yosina.transliterators.ProlongedSoundMarksTransliterator;
  * This example demonstrates complex text processing scenarios.
  */
 public class AdvancedUsage {
+    /** Utility class; do not instantiate. */
+    private AdvancedUsage() {}
+
+    /**
+     * Runs the advanced usage examples.
+     *
+     * @param args command-line arguments (unused)
+     */
     public static void main(String[] args) {
         System.out.println("=== Advanced Yosina Java Usage Examples ===\n");
 

--- a/java/examples/src/main/java/examples/BasicUsage.java
+++ b/java/examples/src/main/java/examples/BasicUsage.java
@@ -10,6 +10,14 @@ import io.yosina.Yosina;
  * as shown in the README documentation.
  */
 public class BasicUsage {
+    /** Utility class; do not instantiate. */
+    private BasicUsage() {}
+
+    /**
+     * Runs the basic usage examples.
+     *
+     * @param args command-line arguments (unused)
+     */
     public static void main(String[] args) {
         System.out.println("=== Yosina Java Basic Usage Example ===\n");
 

--- a/java/examples/src/main/java/examples/ConfigBasedUsage.java
+++ b/java/examples/src/main/java/examples/ConfigBasedUsage.java
@@ -14,6 +14,14 @@ import io.yosina.transliterators.ProlongedSoundMarksTransliterator;
  * This example demonstrates using direct transliterator configurations.
  */
 public class ConfigBasedUsage {
+    /** Utility class; do not instantiate. */
+    private ConfigBasedUsage() {}
+
+    /**
+     * Runs the configuration-based usage examples.
+     *
+     * @param args command-line arguments (unused)
+     */
     public static void main(String[] args) {
         System.out.println("=== Yosina Java Configuration-based Usage Example ===\n");
 


### PR DESCRIPTION
## Summary

- Added missing Javadoc comments across Java codegen classes (`AnnotationProcessor`, `Artifact`, `CircledOrSquaredRecord`, `CodeGenerator`, `HyphensRecord`, `IvsSvsBaseRecord`, `IvsSvsPair`, `KanjiOldNewRecord`, `Main`, `RomanNumeralsRecord`)
- Added Javadoc to generator classes (`CircledOrSquaredTransliteratorGenerator`, `CombinedTransliteratorGenerator`, `HyphensTransliteratorGenerator`, `IvsSvsBaseTransliteratorGenerator`, `TransliteratorGenerator`)
- Added Javadoc to example files (`AdvancedUsage`, `BasicUsage`, `ConfigBasedUsage`)

## Test plan

- [ ] Verify Javadoc generates without warnings (`javadoc` or `mvn javadoc:javadoc`)
- [ ] Confirm no functional changes (existing tests should pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)