### PR TITLE
fix: swift docs generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -509,7 +509,7 @@ $(DART_DOC_MARKER): $(DART_GENERATED)
 
 $(SWIFT_DOC_MARKER): $(SWIFT_GENERATED)
 	@echo -e "$(BLUE)Building Swift API docs...$(NC)"
-	@cd swift && swift-docc generate --target Yosina --output-path .build/documentation
+	@cd swift && swift package --allow-writing-to-package-directory generate-documentation --target Yosina --output-path .build/documentation
 
 .PHONY: sync-split-repos
 sync-split-repos: sync-split-repo-php sync-split-repo-swift

--- a/swift/.gitignore
+++ b/swift/.gitignore
@@ -11,3 +11,4 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+Package.resolved

--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -15,6 +15,9 @@ let package = Package(
             targets: ["Yosina"]
         ),
     ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.4.5"),
+    ],
     targets: [
         .target(
             name: "Yosina",


### PR DESCRIPTION
## Summary
- Switch Swift documentation generation from the standalone `swift-docc` CLI to the `swift-docc-plugin` package plugin (`swift package generate-documentation`), which is the standard approach for SwiftPM projects
- Add `swift-docc-plugin` as a package dependency in `Package.swift`
- Add `Package.resolved` to `.gitignore`

## Test plan
- [x] Verify `make swift-docs` generates documentation successfully
- [x] Verify the generated docs output matches expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)