### PR TITLE
fix: add missing javadoc comments to Java codegen

### DIFF
--- a/java/codegen/src/main/java/io/yosina/codegen/UnicodeUtils.java
+++ b/java/codegen/src/main/java/io/yosina/codegen/UnicodeUtils.java
@@ -5,10 +5,17 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /** Utility class for Unicode operations. */
-public class UnicodeUtils {
+public final class UnicodeUtils {
+    private UnicodeUtils() {}
+
     private static final Pattern UNICODE_PATTERN = Pattern.compile("^U\\+([0-9A-Fa-f]+)$");
 
-    /** Parse a Unicode codepoint representation like "U+1234" to integer. */
+    /**
+     * Parse a Unicode codepoint representation like "U+1234" to integer.
+     *
+     * @param cpRepr the Unicode codepoint representation string
+     * @return the parsed codepoint as an integer
+     */
     public static int parseUnicodeCodepoint(String cpRepr) {
         if (cpRepr == null) {
             return -1;
@@ -23,19 +30,35 @@ public class UnicodeUtils {
         return Integer.parseInt(matcher.group(1), 16);
     }
 
+    /**
+     * Parse a list of Unicode codepoint representations to an int array.
+     *
+     * @param cpReprs the list of Unicode codepoint representation strings
+     * @return the parsed codepoints as an int array, or {@code null} if the input is {@code null}
+     */
     public static int[] parseUnicodeCodepoint(List<String> cpReprs) {
         return cpReprs == null
                 ? null
                 : cpReprs.stream().mapToInt(UnicodeUtils::parseUnicodeCodepoint).toArray();
     }
 
-    /** Convert a Unicode codepoint representation like "U+1234" to a String. */
+    /**
+     * Convert a Unicode codepoint representation like "U+1234" to a String.
+     *
+     * @param cpRepr the Unicode codepoint representation string
+     * @return the corresponding String
+     */
     public static String unicodeToString(String cpRepr) {
         int codepoint = parseUnicodeCodepoint(cpRepr);
         return new String(Character.toChars(codepoint));
     }
 
-    /** Escape a string for Java code generation. */
+    /**
+     * Escape a string for Java code generation.
+     *
+     * @param str the string to escape
+     * @return the escaped string
+     */
     public static String escapeJavaString(String str) {
         if (str == null) {
             return "null";

--- a/java/codegen/src/main/java/io/yosina/codegen/generators/SimpleTransliteratorGenerator.java
+++ b/java/codegen/src/main/java/io/yosina/codegen/generators/SimpleTransliteratorGenerator.java
@@ -65,6 +65,11 @@ public class SimpleTransliteratorGenerator implements TransliteratorGenerator {
     private final String name;
     private final Map<int[], int[]> mappings;
 
+    /**
+     * Build the binary data for the transliterator mappings.
+     *
+     * @return a ByteBuffer containing the serialized mappings
+     */
     public ByteBuffer buildData() {
         ByteBuffer buf = ByteBuffer.allocate(mappings.size() * 4 * 4).order(ByteOrder.BIG_ENDIAN);
         for (Map.Entry<int[], int[]> entry :
@@ -105,6 +110,12 @@ public class SimpleTransliteratorGenerator implements TransliteratorGenerator {
                 new Artifact(Artifact.Type.RESOURCE, Path.of(dataFileName), buildData()));
     }
 
+    /**
+     * Create a new SimpleTransliteratorGenerator.
+     *
+     * @param name the transliterator name
+     * @param rawMappings the raw codepoint mappings
+     */
     public SimpleTransliteratorGenerator(String name, Map<int[], int[]> rawMappings) {
         this.name = name;
         this.mappings = rawMappings;


### PR DESCRIPTION
## Summary
- Add proper javadoc `@param` and `@return` tags to all public methods in `UnicodeUtils` and `SimpleTransliteratorGenerator`
- Add private constructor and make `UnicodeUtils` `final` to suppress default-constructor warning
- Fixes all 10 javadoc warnings emitted during `javadoc` task

## Test plan
- [x] Run `./gradlew :codegen:javadoc` and verify zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)