### PR TITLE
fix: Make Transliterator instances Send + Sync

### DIFF
--- a/rust/src/transliterator.rs
+++ b/rust/src/transliterator.rs
@@ -7,7 +7,7 @@ pub enum TransliterationError {
 }
 
 /// A transliterator function that transforms an iterator of characters
-pub trait Transliterator {
+pub trait Transliterator: Send + Sync {
     fn transliterate<'a, 'b>(
         &self,
         pool: &mut CharPool<'a, 'b>,
@@ -37,9 +37,11 @@ where
 impl<T> Transliterator for FnTransliterator<T>
 where
     T: for<'a, 'b> Fn(
-        &mut CharPool<'a, 'b>,
-        &[&'a Char<'a, 'b>],
-    ) -> Result<Vec<&'a Char<'a, 'b>>, TransliterationError>,
+            &mut CharPool<'a, 'b>,
+            &[&'a Char<'a, 'b>],
+        ) -> Result<Vec<&'a Char<'a, 'b>>, TransliterationError>
+        + Send
+        + Sync,
 {
     fn transliterate<'a, 'b>(
         &self,

--- a/rust/src/transliterators/hyphens.rs
+++ b/rust/src/transliterators/hyphens.rs
@@ -75,7 +75,7 @@ impl HyphensMappings {
 
 pub struct HyphensTransliterator<'c> {
     #[allow(clippy::type_complexity)]
-    getters: Vec<Box<dyn Fn(&str) -> Option<&'static str> + 'c>>,
+    getters: Vec<Box<dyn Fn(&str) -> Option<&'static str> + Send + Sync + 'c>>,
 }
 
 impl<'c> Transliterator for HyphensTransliterator<'c> {
@@ -112,7 +112,7 @@ impl<'c> HyphensTransliterator<'c> {
                 .into_iter()
                 .map(|variant| {
                     Box::new(HyphensMappings::get().variant_getter(variant))
-                        as Box<dyn Fn(&str) -> Option<&'static str> + 'c>
+                        as Box<dyn Fn(&str) -> Option<&'static str> + Send + Sync + 'c>
                 })
                 .collect(),
         }

--- a/rust/src/transliterators/ivs_svs_base.rs
+++ b/rust/src/transliterators/ivs_svs_base.rs
@@ -101,7 +101,7 @@ impl<'a> IvsSvsBaseMappings<'a> {
         &'b self,
         mode: IvsSvsBaseMode,
         charset: Charset,
-    ) -> Box<dyn Fn(&str) -> Option<&'a str> + 'b> {
+    ) -> Box<dyn Fn(&str) -> Option<&'a str> + Send + Sync + 'b> {
         use Charset::*;
         use IvsSvsBaseMode::*;
 
@@ -162,7 +162,7 @@ impl Default for IvsSvsBaseTransliteratorOptions {
 pub struct IvsSvsBaseTransliterator {
     options: IvsSvsBaseTransliteratorOptions,
     #[allow(clippy::type_complexity)]
-    getter: Box<dyn Fn(&str) -> Option<&'static str> + 'static>,
+    getter: Box<dyn Fn(&str) -> Option<&'static str> + Send + Sync + 'static>,
 }
 
 impl IvsSvsBaseTransliterator {


### PR DESCRIPTION
## Summary

* Transliterators may be naturally Send + Sync, but it was totally missed.