### PR TITLE
fix: sync __version__ in python/__init__.py and update Makefile to keep it in sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -602,6 +602,7 @@ update-version:
 	@sed -i.bak 's/"version": "[^"]*"/"version": "$(VERSION)"/' javascript/package.json && rm javascript/package.json.bak
 	@sed -i.bak 's/"version": "[^"]*"/"version": "$(VERSION)"/' php/composer.json && rm php/composer.json.bak
 	@sed -i.bak 's/^version = ".*"/version = "$(VERSION)"/' python/pyproject.toml && rm python/pyproject.toml.bak
+	@sed -i.bak 's/^__version__ = ".*"/__version__ = "$(VERSION)"/' python/src/yosina/__init__.py && rm python/src/yosina/__init__.py.bak
 	@sed -i.bak "s/VERSION = .*/VERSION = '$(VERSION)'/" ruby/lib/yosina/version.rb && rm ruby/lib/yosina/version.rb.bak
 	@sed -i.bak 's/^version = ".*"/version = "$(VERSION)"/' rust/Cargo.toml && rm rust/Cargo.toml.bak
 	@sed -i.bak "s/version = '[^']*'/version = '$(VERSION)'/" java/build.gradle && rm java/build.gradle.bak

--- a/python/src/yosina/__init__.py
+++ b/python/src/yosina/__init__.py
@@ -6,7 +6,7 @@ from .transliterator import make_transliterator
 from .transliterators import TransliteratorConfig, TransliteratorIdentifier
 from .types import Transliterator, TransliteratorFactory
 
-__version__ = "0.1.0"
+__version__ = "2.0.0"
 __all__ = [
     "Char",
     "Transliterator",


### PR DESCRIPTION
## Summary

- `__version__` in `python/src/yosina/__init__.py` was hardcoded to `0.1.0` and not updated when the version was bumped to `2.0.0`
- The `update-version` Makefile target was only updating `python/pyproject.toml`, missing `__init__.py`

## Changes

- Updated `__version__` in `__init__.py` to `2.0.0`
- Added a `sed` line in `Makefile`'s `update-version` target to keep `__init__.py` in sync with `pyproject.toml` going forward

## Test plan

- [ ] `python -c "import yosina; print(yosina.__version__)"` outputs `2.0.0`
- [ ] `make update-version VERSION=x.y.z` updates both `pyproject.toml` and `__init__.py`

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)