### PR TITLE
fix: broaden make_transliterator type annotation to accept Transliterator instances

### DIFF
--- a/python/src/yosina/transliterator.py
+++ b/python/src/yosina/transliterator.py
@@ -8,12 +8,13 @@ from .chars import build_char_list, from_chars
 from .intrinsics import make_chained_transliterator
 from .recipes import TransliterationRecipe, build_transliterator_configs_from_recipe
 from .transliterators import TransliteratorConfig, TransliteratorIdentifier
+from .types import Transliterator
 
 __all__ = ["make_transliterator"]
 
 
 def make_transliterator(
-    configs_or_recipe: list[TransliteratorConfig | TransliteratorIdentifier] | TransliterationRecipe,
+    configs_or_recipe: list[TransliteratorConfig | TransliteratorIdentifier | Transliterator] | TransliterationRecipe,
 ) -> Callable[[str], str]:
     """Frontend convenience function to create a string-to-string transliterator.
 


### PR DESCRIPTION
## Summary

- `make_transliterator` accepted only `TransliteratorConfig | TransliteratorIdentifier` in its list parameter
- The underlying `make_chained_transliterator` already accepted `Transliterator` instances, but the narrower annotation caused mypy errors when users passed custom `Transliterator` instances

## Changes

- Added `Transliterator` to the union type in `make_transliterator`'s `configs_or_recipe` parameter, consistent with `make_chained_transliterator`

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)