### PR TITLE
fix: broaden make_transliterator type annotation to accept Transliterator instances

### DIFF
--- a/python/src/yosina/transliterator.py
+++ b/python/src/yosina/transliterator.py
@@ -2,18 +2,19 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 
 from .chars import build_char_list, from_chars
 from .intrinsics import make_chained_transliterator
 from .recipes import TransliterationRecipe, build_transliterator_configs_from_recipe
 from .transliterators import TransliteratorConfig, TransliteratorIdentifier
+from .types import Transliterator
 
 __all__ = ["make_transliterator"]
 
 
 def make_transliterator(
-    configs_or_recipe: list[TransliteratorConfig | TransliteratorIdentifier] | TransliterationRecipe,
+    configs_or_recipe: Sequence[TransliteratorConfig | TransliteratorIdentifier | Transliterator] | TransliterationRecipe,
 ) -> Callable[[str], str]:
     """Frontend convenience function to create a string-to-string transliterator.
 


### PR DESCRIPTION
## Summary

- Adds `Transliterator` to the union of accepted list element types in `make_transliterator`, consistent with the underlying `make_chained_transliterator`
- Switches the parameter type from `list` (invariant) to `Sequence` (covariant) to fix a pyright error where narrower list types (e.g. `list[TransliteratorConfig]`) were not assignable

## Root cause of CI failure in #35

`list` is invariant, so `list[A | B]` is not assignable to `list[A | B | C]`. Switching to `Sequence` resolves this.

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)